### PR TITLE
Deny builds for any gcc-toolset package

### DIFF
--- a/conf/sync2build-packages-denylist.txt
+++ b/conf/sync2build-packages-denylist.txt
@@ -11,8 +11,7 @@ subscription-manager
 thunderbird
 
 # SCL
-gcc-toolset-9*
-gcc-toolset-10*
+gcc-toolset-*
 
 # Secureboot
 fwupd


### PR DESCRIPTION
gcc-toolset-11 was recently added, so we might as well block autobuilds of everything with this prefix because they're all SCLs and must be built in a special build target.