### PR TITLE
Update kmod deny pattern

### DIFF
--- a/conf/sync2build-packages-denylist.txt
+++ b/conf/sync2build-packages-denylist.txt
@@ -19,7 +19,7 @@ fwupdate
 grub2
 kernel
 kernel-rt
-kmod*
+kmod-*
 shim
 shim-unsigned-aarch64
 shim-unsigned-x64


### PR DESCRIPTION
We need to manually build packages like kmod-kvdo, but not kmod itself.