### PR TITLE
Remove filesystem from build denylist

### DIFF
--- a/conf/sync2build-packages-denylist.txt
+++ b/conf/sync2build-packages-denylist.txt
@@ -49,7 +49,6 @@ rhel-system-roles-sap
 sap-cluster-connector
 
 # Newer do not ship ...
-filesystem    # 2020-04-30, rhbz#1827087
 freetype      # 2020-11-18, rhbz#1891906
 liblouis      # 2020-09-28, rhbz#1588626
 mingw-openssl # 2020-10-29, rhbz#1846152


### PR DESCRIPTION
The version-release that was dropped was 3.8-4.el8.  I manually reverted the change in a custom 3.8-4.el8.0.1 to provide a proper upgrade path to CS8 users.  Since then RHEL has created 3.8-6.el8.

https://bugzilla.redhat.com/show_bug.cgi?id=1960739
https://bugzilla.redhat.com/show_bug.cgi?id=1912155